### PR TITLE
Fixed some compile errors when building with Clang

### DIFF
--- a/Source/AsyncStreams/Public/OptionalRef.h
+++ b/Source/AsyncStreams/Public/OptionalRef.h
@@ -1,0 +1,167 @@
+﻿#pragma once
+#include "Misc/Optional.h"
+
+template <typename OptionalType>
+struct TOptional<OptionalType&>
+{
+public:
+	using ElementType = OptionalType&;
+
+	/** Construct an OptionalType with a valid value. */
+	TOptional(OptionalType& InValue)
+		: TOptional(InPlace, &InValue)
+	{
+	}
+
+	explicit TOptional(EInPlace, OptionalType* OptionalValue)
+	{
+		OptionalRefPtr = OptionalValue;
+	}
+
+	/** Construct an OptionalType with an invalid value. */
+	TOptional(FNullOpt)
+		: TOptional()
+	{
+	}
+
+	/** Construct an OptionalType with no value; i.e. unset */
+	TOptional()
+	{
+		OptionalRefPtr = nullptr;
+	}
+
+	~TOptional()
+	{
+		Reset();
+	}
+
+	/** Copy/Move construction */
+	TOptional(const TOptional& Other)
+	{
+		OptionalRefPtr = Other.OptionalRefPtr;
+	}
+
+	TOptional(TOptional&& Other)
+	{
+		Swap(OptionalRefPtr, Other.OptionalRefPtr);
+	}
+
+	TOptional& operator=(const TOptional& Other)
+	{
+		if (&Other != this)
+		{
+			OptionalRefPtr = Other.OptionalRefPtr;
+		}
+		return *this;
+	}
+
+	TOptional& operator=(TOptional&& Other)
+	{
+		if (&Other != this)
+		{
+			Swap(OptionalRefPtr, Other.OptionalRefPtr);
+		}
+		return *this;
+	}
+
+	TOptional& operator=(OptionalType& InValue)
+	{
+		OptionalRefPtr = &InValue;
+		return *this;
+	}
+
+	TOptional& operator=(OptionalType&& InValue)
+	{
+		OptionalRefPtr = &InValue;
+		return *this;
+	}
+
+	void Reset()
+	{
+		OptionalRefPtr = nullptr;
+	}
+
+	OptionalType& Emplace(OptionalType& InValue)
+	{
+		OptionalRefPtr = &InValue;
+		return *OptionalRefPtr;
+	}
+
+	friend bool operator==(const TOptional& Lhs, const TOptional& Rhs)
+	{
+		return Lhs.OptionalRefPtr == Rhs.OptionalRefPtr;
+	}
+
+	friend bool operator!=(const TOptional& Lhs, const TOptional& Rhs)
+	{
+		return !(Lhs == Rhs);
+	}
+
+	void Serialize(FArchive& Ar)
+	{
+		Ar << OptionalRefPtr;
+	}
+
+	/** @return true when the value is meaningful; false if calling GetValue() is undefined. */
+	bool IsSet() const
+	{
+		return OptionalRefPtr != nullptr;
+	}
+
+	FORCEINLINE explicit operator bool() const
+	{
+		return IsSet();
+	}
+
+	/** @return The optional value; undefined when IsSet() returns false. */
+	OptionalType& GetValue()
+	{
+		checkf(IsSet(), TEXT("It is an error to call GetValue() on an unset TOptional. Please either check IsSet() or use Get(DefaultValue) instead."));
+		return *OptionalRefPtr;
+	}
+
+	FORCEINLINE const OptionalType& GetValue() const
+	{
+		return const_cast<TOptional*>(this)->GetValue();
+	}
+
+	OptionalType* operator->()
+	{
+		return &GetValue();
+	}
+
+	FORCEINLINE const OptionalType* operator->() const
+	{
+		return const_cast<TOptional*>(this)->operator->();
+	}
+
+	OptionalType& operator*()
+	{
+		return GetValue();
+	}
+
+	FORCEINLINE const OptionalType& operator*() const
+	{
+		return const_cast<TOptional*>(this)->operator*();
+	}
+
+	/** @return The optional value when set; DefaultValue otherwise. */
+	const OptionalType& Get(const OptionalType& DefaultValue UE_LIFETIMEBOUND) const UE_LIFETIMEBOUND
+	{
+		return IsSet() ? *(const OptionalType*)OptionalRefPtr : DefaultValue;
+	}
+
+	/** @return A pointer to the optional value when set, nullptr otherwise. */
+	OptionalType* GetPtrOrNull()
+	{
+		return IsSet() ? (OptionalType*)OptionalRefPtr : nullptr;
+	}
+
+	FORCEINLINE const OptionalType* GetPtrOrNull() const
+	{
+		return const_cast<TOptional*>(this)->GetPtrOrNull();
+	}
+
+private:
+	OptionalType* OptionalRefPtr;
+};

--- a/Source/AsyncStreamsTests/Private/WeakPromise.spec.cpp
+++ b/Source/AsyncStreamsTests/Private/WeakPromise.spec.cpp
@@ -69,8 +69,9 @@ void WeakPromiseSpec::Define()
 			TWeakPromise<void> Promise;
 			{
 				TWeakFuture<void> Future = Promise.GetWeakFuture();
-				Future.Next([&bFollowUpEventWasCalled](bool bValueSet)
+				Future.Next([this, &bFollowUpEventWasCalled](bool bValueSet)
 				{
+					TestTrue("bValueSet", bValueSet);
 					bFollowUpEventWasCalled = true;
 				});
 			}
@@ -84,8 +85,9 @@ void WeakPromiseSpec::Define()
 			TWeakPromise<void> Promise;
 			{
 				TWeakFuture<void> Future = Promise.GetWeakFuture();
-				Future.Next([&bFollowUpEventWasCalled](bool bValueSet)
+				Future.Next([this, &bFollowUpEventWasCalled](bool bValueSet)
 				{
+					TestFalse("bValueSet", bValueSet);
 					bFollowUpEventWasCalled = true;
 				});
 			}

--- a/Source/Tentacle/Private/Contexts/AutoInjectableInterface.cpp
+++ b/Source/Tentacle/Private/Contexts/AutoInjectableInterface.cpp
@@ -1,11 +1,11 @@
 ﻿// Copyright singinwhale https://www.singinwhale.com and contributors. Distributed under the MIT license.
-#include "Contexts/AutoInjectable.h"
+#include "Contexts/AutoInjectableInterface.h"
 
 #include "Tentacle.h"
 #include "Contexts/AutoInjector.h"
 #include "Contexts/DIContextInterface.h"
 
-bool DI::RequestAutoInject(TScriptInterface<IAutoInjectable> AutoInjectableObject)
+bool DI::RequestAutoInject(TScriptInterface<IAutoInjectableInterface> AutoInjectableObject)
 {
 	if (!AutoInjectableObject.GetObject())
 		return false;

--- a/Source/Tentacle/Private/Contexts/AutoInjector.cpp
+++ b/Source/Tentacle/Private/Contexts/AutoInjector.cpp
@@ -4,11 +4,11 @@
 #include "Contexts/AutoInjector.h"
 
 
-void IAutoInjector::RequestInitialize(const TScriptInterface<IAutoInjectable>& InitializationTarget)
+void IAutoInjector::RequestInitialize(const TScriptInterface<IAutoInjectableInterface>& InitializationTarget)
 {
-	if (ensureAlwaysMsgf(InitializationTarget.GetObject() && InitializationTarget.GetObject()->Implements<UAutoInjectable>(), TEXT("Invalid Target")))
+	if (ensureAlwaysMsgf(InitializationTarget.GetObject() && InitializationTarget.GetObject()->Implements<UAutoInjectableInterface>(), TEXT("Invalid Target")))
 	{
 		TScriptInterface<IDiContextInterface> DiContext = CastChecked<UObject>(this);
-		IAutoInjectable::Execute_AutoInject(InitializationTarget.GetObject(), DiContext);
+		IAutoInjectableInterface::Execute_AutoInject(InitializationTarget.GetObject(), DiContext);
 	}
 }

--- a/Source/Tentacle/Private/Contexts/DiContextInterface.cpp
+++ b/Source/Tentacle/Private/Contexts/DiContextInterface.cpp
@@ -2,6 +2,8 @@
 
 
 #include "TentacleSettings.h"
+#include "Components/PanelWidget.h"
+#include "Components/Widget.h"
 #include "Contexts/DiContextComponent.h"
 #include "Contexts/DIContextInterface.h"
 #include "Contexts/DiEngineSubsystem.h"
@@ -22,6 +24,15 @@ TScriptInterface<IDiContextInterface> DI::TryFindDiContext(UObject* StartObject)
 		if (AActor* OwnerActor = ActorComponent->GetOwner())
 		{
 			return TryFindDiContext(OwnerActor);
+		}
+	}
+
+	
+	if (UWidget* Widget = Cast<UWidget>(StartObject))
+	{
+		if (Cast<UGameInstance>(Widget->GetOuter()))
+		{
+			return TryFindDiContext(Widget->GetOwningPlayer());
 		}
 	}
 

--- a/Source/Tentacle/Private/TypeId.cpp
+++ b/Source/Tentacle/Private/TypeId.cpp
@@ -3,7 +3,7 @@
 
 #include "TypeId.h"
 
-FName FTypeId::GetName() const
+FName DI::FTypeId::GetName() const
 {
 	switch (Type)
 	{

--- a/Source/Tentacle/Public/Container/Binding.h
+++ b/Source/Tentacle/Public/Container/Binding.h
@@ -72,20 +72,19 @@ namespace DI
 	};
 
 
-	template <class T>
-	class TUInterfaceDependencyBinding final : public FBinding
+	class FUInterfaceDependencyBinding : public FBinding
 	{
 	public:
 		using Super = FBinding;
 
-		TScriptInterface<T> InterfaceDependency;
+		FScriptInterface InterfaceDependency;
 
-		TUInterfaceDependencyBinding(FBindingId BindingId, const TScriptInterface<T>& InInterface)
+		FUInterfaceDependencyBinding(FBindingId BindingId, const FScriptInterface& InInterface)
 			: Super(BindingId), InterfaceDependency(InInterface)
 		{
 		}
 
-		const TScriptInterface<T>& Resolve() const
+		const FScriptInterface& Resolve() const
 		{
 			return InterfaceDependency;
 		}
@@ -94,6 +93,24 @@ namespace DI
 		{
 			Super::AddReferencedObjects(Collector);
 			InterfaceDependency.AddReferencedObjects(Collector);
+		}
+	};
+
+	template <class T>
+	class TUInterfaceDependencyBinding final : public FUInterfaceDependencyBinding
+	{
+	public:
+		using Super = FUInterfaceDependencyBinding;
+
+
+		TUInterfaceDependencyBinding(FBindingId BindingId, const TScriptInterface<T>& InInterface)
+			: Super(BindingId, InInterface)
+		{
+		}
+
+		TScriptInterface<T> Resolve() const
+		{
+			return TScriptInterface<T>(InterfaceDependency.GetObject());
 		}
 	};
 

--- a/Source/Tentacle/Public/Container/BindingId.h
+++ b/Source/Tentacle/Public/Container/BindingId.h
@@ -57,11 +57,6 @@ namespace DI
 			&& A.GetBindingName() == B.GetBindingName();
 	}
 
-	FORCEINLINE uint32 GetTypeHash(const FBindingId& Binding)
-	{
-		return HashCombine(GetTypeHash(Binding.GetBoundTypeId()), GetTypeHash(Binding.GetBindingName()));
-	}
-
 	template <class T>
 	static FBindingId MakeBindingId()
 	{
@@ -73,4 +68,15 @@ namespace DI
 	{
 		return FBindingId(DI::GetTypeId<T>(), MoveTemp(BindingName));
 	}
+
+	
+	FORCEINLINE uint32 GetTypeHash(const DI::FBindingId& Binding)
+	{
+		return HashCombine(::GetTypeHash(Binding.GetBoundTypeId()), GetTypeHash(Binding.GetBindingName()));
+	}
+}
+
+FORCEINLINE uint32 GetTypeHash(const DI::FBindingId& Binding)
+{
+	return DI::GetTypeHash(Binding);
 }

--- a/Source/Tentacle/Public/Container/DiContainerConcept.h
+++ b/Source/Tentacle/Public/Container/DiContainerConcept.h
@@ -5,7 +5,6 @@
 #include "BindingSubscriptionList.h"
 #include "Binding.h"
 #include "Templates/Models.h"
-#include "TentacleTemplates.h"
 
 namespace DI
 {
@@ -47,11 +46,24 @@ namespace DI
 		);
 	};
 
+	namespace Private
+	{
+		// PS5 is missing <concepts> C++20 library.
+		// Backport std::convertible_to manually.
+		template <class From, class To>
+		concept convertible_to =
+			std::is_convertible_v<From, To> &&
+			requires
+			{
+				static_cast<To>(std::declval<From>());
+			};
+	}
+
 	template <class T>
 	concept DiContainerConcept = requires(T DiContainer)
 	{
-		{ DiContainer.BindSpecific(DeclVal<TSharedRef<DI::FBinding>>(), DeclVal<EBindConflictBehavior>()) } -> std::convertible_to<EBindResult>;
-		{ DiContainer.FindBinding(DeclVal<const FBindingId&>()) } -> std::convertible_to<TSharedPtr<DI::FBinding>>;
-		{ DiContainer.Subscribe(DeclVal<const FBindingId&>()) } -> std::convertible_to<FBindingSubscriptionList::FOnInstanceBound&>;
+		{ DiContainer.BindSpecific(DeclVal<TSharedRef<DI::FBinding>>(), DeclVal<EBindConflictBehavior>()) } -> Private::convertible_to<EBindResult>;
+		{ DiContainer.FindBinding(DeclVal<const FBindingId&>()) } -> Private::convertible_to<TSharedPtr<DI::FBinding>>;
+		{ DiContainer.Subscribe(DeclVal<const FBindingId&>()) } -> Private::convertible_to<FBindingSubscriptionList::FOnInstanceBound&>;
 	};
 }

--- a/Source/Tentacle/Public/Container/ResolveHelper.h
+++ b/Source/Tentacle/Public/Container/ResolveHelper.h
@@ -236,7 +236,10 @@ namespace DI
 			UObject* WaitingObject,
 			FName BindingNames...) const
 		{
-			return TryResolveFutureNamedInstances<Ts...>(WaitingObject, GDefaultResolveErrorBehavior, BindingNames...);
+			TTuple<TWeakFuture<TBindingInstRef<Ts>>...> Futures = TTuple<TWeakFuture<TBindingInstRef<Ts>>...>(
+				this->TryResolveFutureNamedInstance<Ts>(BindingNames, WaitingObject, GDefaultResolveErrorBehavior)...
+			);
+			return AwaitAllWeak(MoveTemp(Futures));
 		}
 
 		/**

--- a/Source/Tentacle/Public/Contexts/AutoInjectableInterface.h
+++ b/Source/Tentacle/Public/Contexts/AutoInjectableInterface.h
@@ -4,11 +4,11 @@
 
 #include "CoreMinimal.h"
 #include "UObject/Interface.h"
-#include "AutoInjectable.generated.h"
+#include "AutoInjectableInterface.generated.h"
 
 class IDiContextInterface;
 UINTERFACE(Blueprintable)
-class UAutoInjectable : public UInterface
+class UAutoInjectableInterface : public UInterface
 {
 	GENERATED_BODY()
 };
@@ -17,7 +17,7 @@ class UAutoInjectable : public UInterface
  * Implement this interface on components that require auto initialization.
  * If you are not sure if someone will call AutoInject on you already, you can use IAutoInjector to request initialization from a supporting context.
  */
-class TENTACLE_API IAutoInjectable
+class TENTACLE_API IAutoInjectableInterface
 {
 	GENERATED_BODY()
 
@@ -34,5 +34,5 @@ namespace DI
 	 * @param AutoInjectableObject The injectable to be initialized
 	 * @return true if an auto injector has been found
 	 */
-	TENTACLE_API bool RequestAutoInject(TScriptInterface<IAutoInjectable> AutoInjectableObject);
+	TENTACLE_API bool RequestAutoInject(TScriptInterface<IAutoInjectableInterface> AutoInjectableObject);
 }

--- a/Source/Tentacle/Public/Contexts/AutoInjector.h
+++ b/Source/Tentacle/Public/Contexts/AutoInjector.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "AutoInjectable.h"
+#include "AutoInjectableInterface.h"
 #include "DIContextInterface.h"
 #include "UObject/Interface.h"
 #include "AutoInjector.generated.h"
@@ -29,5 +29,5 @@ public:
 	 * @param InitializationTarget The object that wants AutoInject to be called as soon as possible.
 	 */
 	UFUNCTION(BlueprintCallable, Category="Dependency Injection")
-	virtual void RequestInitialize(const TScriptInterface<IAutoInjectable>& InitializationTarget);
+	virtual void RequestInitialize(const TScriptInterface<IAutoInjectableInterface>& InitializationTarget);
 };

--- a/Source/Tentacle/Public/Contexts/DIContextInterface.h
+++ b/Source/Tentacle/Public/Contexts/DIContextInterface.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "AutoInjectable.h"
+#include "AutoInjectableInterface.h"
 #include "UObject/Interface.h"
 #include "DIContextInterface.generated.h"
 

--- a/Source/Tentacle/Public/Contexts/DiBlueprintFunctionLibrary.h
+++ b/Source/Tentacle/Public/Contexts/DiBlueprintFunctionLibrary.h
@@ -20,6 +20,10 @@ class TENTACLE_API UDiBlueprintFunctionLibrary : public UBlueprintFunctionLibrar
 	GENERATED_BODY()
 
 public:
+
+	UFUNCTION(BlueprintCallable, Category="Dependency Injection", meta=(DefaultToSelf="ContextObject"))
+	static TScriptInterface<IDiContextInterface> FindDiContextForObject(UObject* ContextObject);
+	
 	/**
 	 * Request auto injetion on a AutoInjectable.
 	 * @param AutoInjectableObject the object to be initialized via IAutoInjectable::AutoInject
@@ -27,7 +31,7 @@ public:
 	 * @return True if initialization has been requested. False if no IAutoInjector has been found.
 	 */
 	UFUNCTION(BlueprintCallable, Category="Dependency Injection", meta = (DefaultToSelf = "AutoInjectableObject", ExpandBoolAsExecs="bResult"))
-	static bool RequestAutoInject(TScriptInterface<IAutoInjectable> AutoInjectableObject, bool& bResult);
+	static bool RequestAutoInject(TScriptInterface<IAutoInjectableInterface> AutoInjectableObject, bool& bResult);
 
 
 	/**
@@ -39,6 +43,16 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category="Dependency Injection", meta = (DeterminesOutputType = "ObjectType", DefaultToSelf = "DiContextInterface"))
 	static UObject* TryResolveObject( TScriptInterface<IDiContextInterface> DiContextInterface, UClass* ObjectType, FName BindingName);
+
+	/**
+	 * Resolve a single interface instance from the context.
+	 * @param DiContextInterface The context that has the bindings
+	 * @param ObjectType the UClass of the object to be resolved
+	 * @param BindingName Name of the binding or None for a type binding
+	 * @return The resolved object or None if the object is not bound.
+	 */
+	UFUNCTION(BlueprintCallable, Category="Dependency Injection", meta = (DeterminesOutputType = "InterfaceType", DefaultToSelf = "DiContextInterface"))
+	static TScriptInterface<IInterface> TryResolveInterface( TScriptInterface<IDiContextInterface> DiContextInterface, UClass* InterfaceType, FName BindingName);
 
 
 	/**

--- a/Source/Tentacle/Public/TypeId.h
+++ b/Source/Tentacle/Public/TypeId.h
@@ -5,11 +5,14 @@
 #include "CoreMinimal.h"
 #include "TentacleTemplates.h"
 #include "UObject/Object.h"
-#include <concepts>
 
-class FTypeId;
 
-uint32 GetTypeHash(const FTypeId&);
+namespace DI
+{
+	class FTypeId;
+}
+
+uint32 GetTypeHash(const DI::FTypeId& TypeId);
 
 namespace DI
 {
@@ -23,7 +26,6 @@ namespace DI
 		{
 		};
 	}
-}
 
 /**
  * RTTI-like type ID that uses either UObject information or manually defined type names for native types.
@@ -41,8 +43,8 @@ namespace DI
  */
 class TENTACLE_API FTypeId
 {
-	friend FTypeId DI::Private::MakeNativeTypeId(const TCHAR* TypeName);
-	friend uint32 GetTypeHash(const FTypeId&);
+	friend FTypeId Private::MakeNativeTypeId(const TCHAR* TypeName);
+	friend auto ::GetTypeHash(const FTypeId&) -> uint32;
 
 private:
 	enum class EIdType : uint8
@@ -165,7 +167,9 @@ public:
 	}
 };
 
-FORCEINLINE uint32 GetTypeHash(const FTypeId& TypeId)
+}
+
+FORCEINLINE uint32 GetTypeHash(const DI::FTypeId& TypeId)
 {
 	return HashCombine(GetTypeHash(TypeId.Type), GetTypeHash(TypeId.GetTypeIdAddress()));
 }
@@ -173,7 +177,7 @@ FORCEINLINE uint32 GetTypeHash(const FTypeId& TypeId)
 #define DI_TYPEID_BODY(TypeName)\
 	static_assert(sizeof(TypeName) != 0, #TypeName " does not name a type.");\
 	static const TCHAR* TypeName ## TypeName = TEXT(PREPROCESSOR_TO_STRING(TypeName)); \
-	static const FTypeId TypeName ## TypeId = DI::Private::MakeNativeTypeId(TypeName ## TypeName);\
+	static const ::DI::FTypeId TypeName ## TypeId = ::DI::Private::MakeNativeTypeId(TypeName ## TypeName);\
 	return TypeName ## TypeId;
 
 /**
@@ -182,7 +186,7 @@ FORCEINLINE uint32 GetTypeHash(const FTypeId& TypeId)
  * @param TypeName Type of the class. Can include namespace declarations.
  */
 #define DI_DEFINE_NATIVE_TYPEID_MEMBER(TypeName)\
-		FORCEINLINE static const FTypeId& GetTypeId()\
+		FORCEINLINE static const ::DI::FTypeId& GetTypeId()\
 		{ \
 			DI_TYPEID_BODY(TypeName)\
 		}

--- a/Source/Tentacle/Tentacle.Build.cs
+++ b/Source/Tentacle/Tentacle.Build.cs
@@ -26,6 +26,7 @@ public class Tentacle : ModuleRules
 				"CoreUObject",
 				"Slate",
 				"SlateCore",
+				"UMG",
 			}
 		);
 	}

--- a/Source/TentacleTests/Private/Examples/ExampleActor.cpp
+++ b/Source/TentacleTests/Private/Examples/ExampleActor.cpp
@@ -17,9 +17,9 @@ void AExampleActor::BeginPlay()
 
 void AExampleActor::ComponentRegistered(UActorComponent* Component)
 {
-	if (IAutoInjectable* AutoInjectable = Cast<IAutoInjectable>(Component))
+	if (IAutoInjectableInterface* AutoInjectable = Cast<IAutoInjectableInterface>(Component))
 	{
-		IAutoInjectable::Execute_AutoInject(Component, this);
+		IAutoInjectableInterface::Execute_AutoInject(Component, this);
 	}
 }
 

--- a/Source/TentacleTests/Private/Examples/ExampleComponent.h
+++ b/Source/TentacleTests/Private/Examples/ExampleComponent.h
@@ -4,14 +4,14 @@
 
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
-#include "Contexts/AutoInjectable.h"
+#include "Contexts/AutoInjectableInterface.h"
 #include "ExampleComponent.generated.h"
 
 
 class USimpleUService;
 
 UCLASS(HideDropdown, NotBlueprintable)
-class TENTACLETESTS_API UExampleComponent : public UActorComponent, public IAutoInjectable
+class TENTACLETESTS_API UExampleComponent : public UActorComponent, public IAutoInjectableInterface
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION
When building with Clang some templates had issues compiling. 

WeakFuture::Next could not specialize to void and concepts.h does not exist on some platform.